### PR TITLE
Added a check before execute Rectangle.validate

### DIFF
--- a/src/viewModels/ResetViewNavigationControl.js
+++ b/src/viewModels/ResetViewNavigationControl.js
@@ -113,7 +113,7 @@ ResetViewNavigationControl.prototype.resetView = function () {
         this.terria.options.defaultResetView instanceof Rectangle
       ) {
         try {
-          Rectangle.validate(this.terria.options.defaultResetView);
+          Rectangle.validate && Rectangle.validate(this.terria.options.defaultResetView);
           camera.flyTo({
             destination: this.terria.options.defaultResetView,
             orientation,


### PR DESCRIPTION
Cesium 1.124 has removed the Rectangle.validate method, which results in an error message "Cesium-navigation/ResetViewNavigationControl: options.defaultResetView Cesium rectangle is invalid!" when resetting, making it impossible to reset. Rectangle.validate has been replaced by the internal method Rectangle._validate.

https://github.com/cesium-plugin/cesium-navigation-es6/issues/19